### PR TITLE
Zendrive no longer has V2 endpoints.

### DIFF
--- a/lib/zendrive/configuration.rb
+++ b/lib/zendrive/configuration.rb
@@ -1,14 +1,13 @@
 module Zendrive
   module Configuration
     VALID_CONNECTION_KEYS = [:endpoint, :user_agent].freeze
-    VALID_OPTIONS_KEYS    = [:api_key, :format, :api_version].freeze
+    VALID_OPTIONS_KEYS    = [:api_key, :format].freeze
     VALID_CONFIG_KEYS     = VALID_CONNECTION_KEYS + VALID_OPTIONS_KEYS
 
     DEFAULT_ENDPOINT      = "https://api.zendrive.com"
     DEFAULT_USER_AGENT    = "Zendrive Ruby Gem #{Zendrive::VERSION}".freeze
     DEFAULT_API_KEY       = nil
     DEFAULT_FORMAT        = :json
-    DEFAULT_VERSION       = "v2"
 
     attr_accessor *VALID_CONFIG_KEYS
 
@@ -25,7 +24,6 @@ module Zendrive
       self.user_agent = DEFAULT_USER_AGENT
       self.api_key    = DEFAULT_API_KEY
       self.format     = DEFAULT_FORMAT
-      self.api_version    = DEFAULT_VERSION
     end
   end
 end

--- a/lib/zendrive/driver.rb
+++ b/lib/zendrive/driver.rb
@@ -12,11 +12,7 @@ module Zendrive
       @driver_id = attributes["driver_id"]
       @info = Util::DeepStruct.new(attributes["info"])
       @rank = attributes["rank"]
-      if Zendrive.api_version == "v2"
-        @score = Util::DeepStruct.new(attributes["score"])
-      elsif Zendrive.api_version == "v3"
-        @driving_behavior = Util::DeepStruct.new(attributes["driving_behavior"])
-      end
+      @driving_behavior = Util::DeepStruct.new(attributes["driving_behavior"])
 
       @recommendation = attributes["recommendation"]
     end

--- a/lib/zendrive/driver.rb
+++ b/lib/zendrive/driver.rb
@@ -4,8 +4,7 @@ module Zendrive
     SINGLE_ENDPOINT = "driver"
     RESOURCE_NAME = "drivers"
 
-    attr_reader :id, :driver_id, :info, :rank, :score, :recommendation,
-                :driving_behavior
+    attr_reader :id, :driver_id, :info, :rank, :recommendation, :driving_behavior
 
     def initialize(attributes)
       @id = attributes["driver_id"]

--- a/lib/zendrive/findable.rb
+++ b/lib/zendrive/findable.rb
@@ -15,7 +15,7 @@ module Zendrive
 
     # Combine the top level API endpoint with the version and the resource specific endpoint
     def self.url_for(endpoint, interpolated_params)
-      [Zendrive.endpoint, Zendrive.api_version, (interpolated_endpoint(endpoint, interpolated_params))].join("/")
+      [Zendrive.endpoint, "v3", (interpolated_endpoint(endpoint, interpolated_params))].join("/")
     end
 
     # Required on all API calls

--- a/lib/zendrive/score.rb
+++ b/lib/zendrive/score.rb
@@ -35,14 +35,5 @@ module Zendrive
 
       attributes
     end
-
-    def convert_drive_hours_to_seconds(hours_string)
-      if hours_string
-        hours, minutes = hours_string.split(":").map(&:to_i)
-        (hours * 3600) + (minutes * 60)
-      else
-        0
-      end
-    end
   end
 end

--- a/lib/zendrive/score.rb
+++ b/lib/zendrive/score.rb
@@ -9,13 +9,7 @@ module Zendrive
     def initialize(attributes)
       attributes = format_attrs(attributes)
       @info = Util::DeepStruct.new(attributes["info"]) if attributes["info"] && attributes["info"].any?
-
-      if Zendrive.api_version == "v2"
-        @score = Util::DeepStruct.new(attributes["score"]) if attributes["score"] && attributes["score"].any?
-        @score_statistics = Util::DeepStruct.new(attributes["score_statistics"]) if attributes["score_statistics"] && attributes["score_statistics"].any?
-      elsif Zendrive.api_version == "v3"
-        @driving_behavior = Util::DeepStruct.new(attributes["driving_behavior"]) if attributes["driving_behavior"] && attributes["driving_behavior"].any?
-      end
+      @driving_behavior = Util::DeepStruct.new(attributes["driving_behavior"]) if attributes["driving_behavior"] && attributes["driving_behavior"].any?
       @speed_profile = attributes["speed_profile"]
       @start_date = attributes["start_date"]
       @end_date = attributes["end_date"]
@@ -23,7 +17,7 @@ module Zendrive
 
     def self.find(driver_id, params)
       req_params = default_params.dup
-      req_params[:params].merge!(fields: send("#{Zendrive.api_version}_fields"))
+      req_params[:params].merge!(fields: "info,driving_behavior")
       req_params[:params].merge!(params)
 
       response = RestClient.get(url_for(self::SINGLE_ENDPOINT, {driver_id: driver_id}), req_params)
@@ -37,11 +31,7 @@ module Zendrive
       if attributes["info"] && attributes["info"].any? && attributes["info"]["distance_km"]
         attributes["info"]["distance_in_km"] = attributes["info"]["distance_km"].to_f
         attributes["info"]["distance_in_mi"] = attributes["info"]["distance_km"].to_f * 0.621371
-        if Zendrive.api_version == "v2"
-          attributes["info"]["drive_time_in_seconds"] = convert_drive_hours_to_seconds(attributes["info"]["drive_time_hours"])
-        elsif Zendrive.api_version == "v3"
-          attributes["info"]["drive_time_in_seconds"] = attributes["info"]["duration_seconds"]
-        end
+        attributes["info"]["drive_time_in_seconds"] = attributes["info"]["duration_seconds"]
       end
 
       attributes
@@ -54,14 +44,6 @@ module Zendrive
       else
         0
       end
-    end
-
-    def self.v2_fields
-      "info,score,score_statistics"
-    end
-
-    def self.v3_fields
-      "info,driving_behavior"
     end
   end
 end

--- a/lib/zendrive/score.rb
+++ b/lib/zendrive/score.rb
@@ -3,8 +3,7 @@ module Zendrive
     SINGLE_ENDPOINT = "driver/{driver_id}/score"
     RESOURCE_NAME = "score"
 
-    attr_reader :info, :score, :score_statistics, :start_date, :end_date,
-                :driving_behavior
+    attr_reader :info, :start_date, :end_date, :driving_behavior
 
     def initialize(attributes)
       attributes = format_attrs(attributes)

--- a/lib/zendrive/trip.rb
+++ b/lib/zendrive/trip.rb
@@ -4,8 +4,7 @@ module Zendrive
     SINGLE_ENDPOINT = "driver/{driver_id}/trip/{trip_id}"
     RESOURCE_NAME = "trips"
 
-    attr_reader :id, :trip_id, :info, :score, :simple_path, :events,
-                :speed_profile, :driving_behavior
+    attr_reader :id, :trip_id, :info, :simple_path, :events, :speed_profile, :driving_behavior
 
     def initialize(attributes)
       @id = attributes["trip_id"]

--- a/lib/zendrive/trip.rb
+++ b/lib/zendrive/trip.rb
@@ -12,11 +12,7 @@ module Zendrive
       @trip_id = attributes["trip_id"]
 
       @info = Util::DeepStruct.new(attributes["info"]) if attributes["info"] && attributes["info"].any?
-      if Zendrive.api_version == "v2"
-        @score = Util::DeepStruct.new(attributes["score"]) if attributes["score"] && attributes["score"].any?
-      elsif Zendrive.api_version == "v3"
-        @driving_behavior = Util::DeepStruct.new(attributes["driving_behavior"]) if attributes["driving_behavior"] && attributes["driving_behavior"].any?
-      end
+      @driving_behavior = Util::DeepStruct.new(attributes["driving_behavior"]) if attributes["driving_behavior"] && attributes["driving_behavior"].any?
 
       @simple_path = attributes["simple_path"]
       @speed_profile = attributes["speed_profile"]
@@ -26,7 +22,7 @@ module Zendrive
     class << self
       def find(driver_id, trip_id)
         params = default_params.dup
-        params[:params].merge!({fields: send("#{Zendrive.api_version}_fields")})
+        params[:params].merge!(fields: "info,driving_behavior,simple_path,events,speed_profile")
 
         response = RestClient.get(
           url_for(SINGLE_ENDPOINT, {driver_id: driver_id, trip_id: trip_id}),
@@ -44,16 +40,6 @@ module Zendrive
         end
 
         response.code == 200
-      end
-
-      private
-
-      def v2_fields
-        "info,score,simple_path,events,speed_profile"
-      end
-
-      def v3_fields
-        "info,driving_behavior,simple_path,events,speed_profile"
       end
     end
   end

--- a/lib/zendrive/version.rb
+++ b/lib/zendrive/version.rb
@@ -1,3 +1,3 @@
 module Zendrive
-  VERSION = "0.2.1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Removing any code that specifies an API version since V3 is now the only available endpoint.

We could leave versioning logic for if and when Zendrive releases a _new_ api version, but that code was not threadsafe, so it would be better if we came up with a better solution for that altogether.